### PR TITLE
upgrade ember-cp-validations@4.0.0-beta.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "ember-buffered-proxy": "^0.7.0 || ^0.8.0 || ^1.0.0",
     "ember-cli-babel": "^6.11.0",
-    "ember-cp-validations": "^3.1.4",
+    "ember-cp-validations": "^4.0.0-beta.6",
     "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove NAME_KEY usage (after upgrade to ember-cp-validations@4.0.0-beta.6)